### PR TITLE
Fix/update git reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-Git 2.19 or greater.
+Git 2.46 or greater required.
 
 ## Quick start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "diffhouse"
 version = "0.2.3"
 dependencies = [
   "pandas >= 2.3.2",
-  "PyYAML >= 6.0.2"
+  "PyYAML >= 6.0.2",
+  "packaging >= 25.0"
 ]
 description = "Metadata extraction tool for git repositories."
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas>=2.3.2
 pytest>=8.4.2
 pdoc>=15.0.4
 twine>=6.2.0
+packaging>=25.0

--- a/src/diffhouse/__init__.py
+++ b/src/diffhouse/__init__.py
@@ -4,10 +4,9 @@ import logging.config
 from importlib import resources
 
 from .repo import Repo
+from .constants import PACKAGE_NAME
 
-PACKAGE_NAME = 'diffhouse'
-
-with (resources.files('diffhouse') / 'static/logging.yml').open('r') as f:
+with (resources.files(PACKAGE_NAME) / 'static/logging.yml').open('r') as f:
     config = yaml.safe_load(f)
     logging.config.dictConfig(config)
 

--- a/src/diffhouse/constants.py
+++ b/src/diffhouse/constants.py
@@ -1,0 +1,2 @@
+PACKAGE_NAME = 'diffhouse'
+MINIMUM_GIT_VERSION = '2.46.0'


### PR DESCRIPTION
## Summary

Minimum git requirement has been updated to 2.46, since this is the first release that has `ls-remote --branches`. Additionally implemented a version check via `GitCLI`. Fixes #14 and fixes #15 .

## Checklist

- [x] Ran tests: `pytest`
- [x] Generated documentation: `pdoc -o docs src/diffhouse`
- [x] Updated `README.md`
